### PR TITLE
Add an id property to each gamepad

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,7 @@ class GamepadHapticActuator {
 }
 class Gamepad {
   constructor(hand, index) {
+    this.id = 'OpenVR Gamepad';
     this.hand = hand;
     this.index = index;
 


### PR DESCRIPTION
This fixes a crash in examples\js\vr\ViveController.js:

```
			if ( gamepad && ( gamepad.id === 'OpenVR Gamepad' || gamepad.id.startsWith( 'Oculus Touch' ) || gamepad.id.startsWith( 'Spatial Controller' ) ) ) {
```

`gamepad.id` was null.