### PR TITLE
Support XBox/PS4 controllers

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,8 +90,9 @@ class GamepadPose {
   }
 }
 class GamepadHapticActuator {
-  constructor(gamepad) {
+  constructor(gamepad, index) {
     this.gamepad = gamepad;
+    this.index = index;
   }
   get type() {
     return 'vibration';
@@ -99,13 +100,13 @@ class GamepadHapticActuator {
   set type(type) {}
   pulse(value, duration) {
     if (this.gamepad.ontriggerhapticpulse) {
-      this.gamepad.ontriggerhapticpulse(value, duration);
+      this.gamepad.ontriggerhapticpulse(value, duration, this.index);
     }
   }
 }
 class Gamepad {
   constructor(hand, index) {
-    this.id = 'OpenVR Gamepad';
+    this.id = (index < 0) ? 'Controller' : 'OpenVR Gamepad';
     this.hand = hand;
     this.index = index;
 
@@ -116,7 +117,9 @@ class Gamepad {
     }
     this.pose = new GamepadPose();
     this.axes = new Float32Array(10);
-    this.hapticActuators = [new GamepadHapticActuator(this)];
+    this.hapticActuators = [
+      new GamepadHapticActuator(this, 0),
+      new GamepadHapticActuator(this, 1)];
 
     this.ontriggerhapticpulse = null;
 
@@ -408,8 +411,9 @@ class FakeVRDisplay extends MRDisplay {
     }
 
     const globalGamepads = getAllGamepads();
-    gamepads[0] = globalGamepads[0];
-    gamepads[1] = globalGamepads[1];
+    for (let i = 0; i < globalGamepads.length; i++) {
+      gamepads[i] = globalGamepads[i];
+    }
   }
 
   requestPresent() {
@@ -467,7 +471,7 @@ class FakeVRDisplay extends MRDisplay {
 
 const createVRDisplay = () => new FakeVRDisplay();
 
-const gamepads = [null, null];
+const gamepads = [null, null, null, null, null, null];
 const getGamepads = () => gamepads;
 
 let allGamepads = null;
@@ -476,6 +480,10 @@ const getAllGamepads = () => {
     allGamepads = [
       new Gamepad('left', 0),
       new Gamepad('right', 1),
+      new Gamepad('player1', -1),
+      new Gamepad('player2', -2),
+      new Gamepad('player3', -3),
+      new Gamepad('player4', -4),
     ];
   }
   return allGamepads;


### PR DESCRIPTION
This is a refactor in preparation for supporting XBox/PS4 controller inputs.

PS4 and XBox controllers have two vibration actuators, so it's necessary to track the actuator index.

XBox/PS4 controllers have a negative `this.index`; VR gamepads have `this.index >= 0`. This is a necessary distinction.